### PR TITLE
Add support for Pydantic models with `alias=`

### DIFF
--- a/fastopenapi/base_router.py
+++ b/fastopenapi/base_router.py
@@ -225,7 +225,9 @@ class BaseRouter:
                 param.annotation, BaseModel
             ):
                 if http_method.upper() == "GET":
-                    model_schema = param.annotation.model_json_schema()
+                    model_schema = param.annotation.model_json_schema(
+                        mode="serialization"
+                    )
                     required_fields = model_schema.get("required", [])
                     properties = model_schema.get("properties", {})
                     for prop_name, prop_schema in properties.items():
@@ -337,7 +339,7 @@ class BaseRouter:
         from pydantic import BaseModel
 
         if isinstance(result, BaseModel):
-            return result.model_dump()
+            return result.model_dump(by_alias=True)
         if isinstance(result, list):
             return [BaseRouter._serialize_response(item) for item in result]
         if isinstance(result, dict):
@@ -356,7 +358,7 @@ class BaseRouter:
         if cache_key not in cls._model_schema_cache:
             # Generate the schema if it's not in the cache
             model_schema = model.model_json_schema(
-                ref_template="#/components/schemas/{model}"
+                mode="serialization", ref_template="#/components/schemas/{model}"
             )
 
             # Process and store nested definitions


### PR DESCRIPTION
## What’s Included?

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation improvement
- [X] Refactor / internal change

**Describe your changes:**

This change ensures that the generated JSON schema / OpenAPI docs match the `alias=` param when present, and that any returned JSON uses the alias for the keys. This is the most consistent behavior with Pydantic's usage, *but* is a breaking change for any existing code that uses `alias=` and relies on FastOpenAPI returning the field name instead of the alias.

We could put this behind a setting if desired instead, i.e.,:

```
# in `_build_parameters_and_body`
model_json_schema(
    mode=("serialization" if self.use_aliases else "validation")
)

# in `_serialize_response`, but note this would probably require making it *not* a `staticmethod`
model_dump(
    by_alias=(True if self.use_aliases else False)
)

```

## How Was It Tested?
Adds a new aliased `computed_field` to the `TestModel`.

## Anything Else?
- [ ] TODO: Determine if this is an appropriate _setting_ or whether it should be controlled via a kwarg to `BaseRouter` (and what the default should be)