### PR TITLE
feat: allow flask router register to bp

### DIFF
--- a/fastopenapi/core/router.py
+++ b/fastopenapi/core/router.py
@@ -38,8 +38,10 @@ class BaseRouter:
         version: str = "0.1.0",
         description: str = "API documentation",
         security_scheme: SecuritySchemeType | None = SecuritySchemeType.BEARER_JWT,
+        blueprint: Any = None,
     ):
         self.app = app
+        self.blueprint = blueprint
         self.docs_url = docs_url
         self.redoc_url = redoc_url
         self.openapi_url = openapi_url
@@ -56,8 +58,9 @@ class BaseRouter:
             scheme_name = SECURITY_SCHEME_NAMES[security_scheme]
             self._security_schemes = {scheme_name: SECURITY_SCHEMES[security_scheme]}
 
-        # Register documentation endpoints if app is provided
-        if self.app is not None and all([docs_url, redoc_url, openapi_url]):
+        # Register documentation endpoints if app or blueprint is provided
+        registration_target = blueprint or app
+        if registration_target is not None and all([docs_url, redoc_url, openapi_url]):
             self._register_docs_endpoints()
 
     def add_route(self, path: str, method: str, endpoint: Callable):

--- a/tests/routers/flask/test_flask_router.py
+++ b/tests/routers/flask/test_flask_router.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Blueprint, Flask
 from pydantic import BaseModel
 
 from fastopenapi.routers import FlaskRouter
@@ -86,3 +86,150 @@ class TestFlaskRouter:
         assert "get" in schema["paths"]["/test/{id}"]
         assert schema["paths"]["/test/{id}"]["get"]["summary"] == "Test endpoint"
         assert "TestModel" in schema["components"]["schemas"]
+
+    def test_router_initialization_with_blueprint(self):
+        """Test router initialization with Blueprint"""
+        app = Flask(__name__)
+        bp = Blueprint("api", __name__, url_prefix="/api")
+
+        router = FlaskRouter(
+            app=app,
+            blueprint=bp,
+            title="Test API",
+            description="Test API Description",
+            version="1.0.0",
+        )
+
+        assert router.title == "Test API"
+        assert router.description == "Test API Description"
+        assert router.version == "1.0.0"
+        assert router.app == app
+        assert router.blueprint == bp
+
+    def test_add_route_to_blueprint(self):
+        """Test adding a route to Blueprint instead of app"""
+        app = Flask(__name__)
+        bp = Blueprint("api", __name__, url_prefix="/api")
+        router = FlaskRouter(app=app, blueprint=bp)
+
+        @router.get("/test")
+        def test_endpoint():
+            return {"message": "Test"}
+
+        routes = router.get_routes()
+
+        # Route should be registered in router
+        assert len(routes) == 1
+        route = routes[0]
+        assert route.path == "/test"
+        assert route.method == "GET"
+        assert route.endpoint == test_endpoint
+
+        # Register blueprint with app to verify registration
+        app.register_blueprint(bp)
+
+        # After registration, verify the route works
+        with app.test_client() as client:
+            response = client.get("/api/test")
+            assert response.status_code == 200
+            data = response.get_json()
+            assert data["message"] == "Test"
+
+    def test_blueprint_fallback_to_app(self):
+        """Test that router falls back to app when blueprint is None"""
+        app = Flask(__name__)
+        router = FlaskRouter(app=app, blueprint=None)
+
+        @router.get("/test")
+        def test_endpoint():
+            return {"message": "Test"}
+
+        # Test the route works directly on app
+        with app.test_client() as client:
+            response = client.get("/test")
+            assert response.status_code == 200
+            data = response.get_json()
+            assert data["message"] == "Test"
+
+    def test_docs_endpoints_on_blueprint(self):
+        """Test that documentation endpoints are registered on blueprint"""
+        app = Flask(__name__)
+        bp = Blueprint("api", __name__, url_prefix="/api")
+        router = FlaskRouter(app=app, blueprint=bp)
+
+        # Register blueprint with app
+        app.register_blueprint(bp)
+
+        # Test that docs endpoints are accessible through blueprint
+        with app.test_client() as client:
+            # Test OpenAPI JSON endpoint
+            response = client.get("/api/openapi.json")
+            assert response.status_code == 200
+
+            # Test Swagger UI endpoint
+            response = client.get("/api/docs")
+            assert response.status_code == 200
+            assert b"html" in response.data.lower()
+
+            # Test ReDoc UI endpoint
+            response = client.get("/api/redoc")
+            assert response.status_code == 200
+            assert b"html" in response.data.lower()
+
+    def test_blueprint_integration_with_app(self):
+        """Test that blueprint with registered routes works with Flask app"""
+        app = Flask(__name__)
+        bp = Blueprint("api", __name__, url_prefix="/api")
+
+        class ItemResponse(BaseModel):
+            id: int
+            name: str
+
+        router = FlaskRouter(app=app, blueprint=bp)
+
+        @router.get("/items/{item_id}", response_model=ItemResponse)
+        def get_item(item_id: int):
+            """Get an item by ID"""
+            return ItemResponse(id=item_id, name=f"Item {item_id}")
+
+        # Register blueprint with app
+        app.register_blueprint(bp)
+
+        # Test the route
+        with app.test_client() as client:
+            response = client.get("/api/items/123")
+            assert response.status_code == 200
+            data = response.get_json()
+            assert data["id"] == 123
+            assert data["name"] == "Item 123"
+
+    def test_openapi_generation_with_blueprint(self):
+        """Test OpenAPI schema generation with blueprint"""
+        app = Flask(__name__)
+        bp = Blueprint("api", __name__, url_prefix="/api")
+
+        router = FlaskRouter(
+            app=app,
+            blueprint=bp,
+            title="Blueprint API",
+            description="API with Blueprint",
+            version="2.0.0",
+        )
+
+        class TestModel(BaseModel):
+            id: int
+            name: str
+
+        @router.get("/test/{id}", response_model=TestModel)
+        def get_test(id: int):
+            """Test endpoint with blueprint"""
+            return TestModel(id=id, name="Blueprint Test")
+
+        schema = router.openapi
+
+        assert schema["info"]["title"] == "Blueprint API"
+        assert schema["info"]["version"] == "2.0.0"
+        assert schema["info"]["description"] == "API with Blueprint"
+        assert "/test/{id}" in schema["paths"]
+        assert "get" in schema["paths"]["/test/{id}"]
+        assert schema["paths"]["/test/{id}"]["get"]["summary"] == "Test endpoint with blueprint"


### PR DESCRIPTION
# Pull Request

Thanks for contributing to FastOpenAPI!  
Before submitting, please make sure you've read [CONTRIBUTING.md](../CONTRIBUTING.md).

---

## What’s Included?

- [ ] New feature
- [x] Bug fix
- [ ] Documentation improvement
- [ ] Refactor / internal change

**Describe your changes:**

> Concise and clear: what did you change, why, and which parts/frameworks are affected?

```
from flask import Flask, Blueprint
from fastopenapi.routers import FlaskRouter

app = Flask(__name__)
bp = Blueprint('api', __name__, url_prefix='/api')

router = FlaskRouter(app=app, blueprint=bp)
```

---

## How Was It Tested?

> Describe how you tested the changes.

test in locally

> Were new tests added? Are examples working?

add new test to cover register to bp, it worked

---

## Anything Else?

> Optional:
> - Any TODOs or follow-up items?
> - Known limitations or trade-offs?
> - Anything you'd like reviewers to focus on?

---
